### PR TITLE
Modified testing scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ venv/
 # Ignore data folders
 resources/data/
 resources/test_images/
+resources/LFWdataset
 run_server.sh
 run_server2.sh
+
+*.DS_Store
 

--- a/benchmark_testing/edgecase_testing.py
+++ b/benchmark_testing/edgecase_testing.py
@@ -47,8 +47,8 @@ def check_face_detection_edge_cases(image_path):
     cv2.destroyAllWindows()
 
 
-image1 = "path\\to\\image1"
-image2 = "path\\to\\image2"
+image1 = "../resources/LFWdataset/sample_queries/Aaron_Peirsol_0004.jpg"
+image2 = "../resources/LFWdataset/sample_queries/Aaron_Sorkin_0001.jpg"
 check_face_detection_edge_cases(image1)
 check_face_detection_edge_cases(image2)
 check_face_recognition_edge_cases(image1, image2)

--- a/benchmark_testing/run_bulk_upload.sh
+++ b/benchmark_testing/run_bulk_upload.sh
@@ -14,7 +14,7 @@ sleep 10
 start_time=$(date +%s)
 
 # Call client script to upload images from to database (the code currently only accepts one directory at a time)
-python ../src/Sample_Client/sample_bulk_upload_client.py --directory_paths "\\path\\to\\sample_database\\directory" --database_name "sample_db"
+python ../src/Sample_Client/sample_bulk_upload_client.py --directory_paths "../resources/LFWdataset/new_sample_database" --database_name "sample_db"
 
 # Sample directory path
 # "<path to dataset folder>\\LFWdataset\\sample_database"
@@ -30,4 +30,4 @@ echo "Server stopped"
 # Print total time taken
 echo "Total time taken: $total_time seconds"
 
-read -p "Press any key to exit..."
+#read -p "Press any key to exit..."

--- a/benchmark_testing/run_cleanup_and_test.sh
+++ b/benchmark_testing/run_cleanup_and_test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Modified main script (run_all.sh)
+
+# Parse command line arguments
+similarity_threshold=0.50  # Default value
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    -t|--threshold) similarity_threshold="$2"; shift ;;
+    *) echo "Unknown parameter: $1"; exit 1 ;;
+  esac
+  shift
+done
+
+# Delete output.csv if it exists
+if [ -f "../resources/LFWdataset/output.csv" ]; then
+  echo "Deleting ../resources/LFWdataset/output.csv"
+  rm "../resources/LFWdataset/output.csv"
+fi
+
+# Delete sample_db.csv and sample_db.bin if they exist
+if [ -f "../resources/data/sample_db.csv" ]; then
+  echo "Deleting ../resources/data/sample_db.csv"
+  rm "../resources/data/sample_db.csv"
+fi
+
+if [ -f "../resources/data/sample_db.bin" ]; then
+  echo "Deleting ../resources/data/sample_db.bin"
+  rm "../resources/data/sample_db.bin"
+fi
+
+# Run the required scripts without waiting for key presses
+echo "Running bulk upload script..."
+# Use modified run_bulk_upload_auto.sh script (see below)
+./run_bulk_upload.sh
+
+echo "Running face find accuracy script..."
+# Pass the similarity threshold to the run_face_find_accuracy.sh script
+./run_face_find_accuracy.sh --threshold $similarity_threshold
+
+echo "Running data metrics script..."
+python test_data_metrics.py
+
+echo "Running confusion matrix script..."
+python test_data_metrics_confusion_matrix.py
+
+echo "All tasks completed."

--- a/benchmark_testing/run_face_find_accuracy.sh
+++ b/benchmark_testing/run_face_find_accuracy.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
-
 export PYTHONPATH=$(pwd)/..
+
+# Parse command line arguments
+similarity_threshold=0.50  # Default value
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    -t|--threshold) similarity_threshold="$2"; shift ;;
+    *) echo "Unknown parameter: $1"; exit 1 ;;
+  esac
+  shift
+done
 
 # Start the Python server in the background
 python ../src/facematch/face_match_server.py &
@@ -14,29 +23,25 @@ sleep 10
 start_time=$(date +%s)
 
 # Define the directory containing the files and the output CSV file
-input_directory="\\path\\to\\input\\directory" # Path to directory of query images
-output_csv="\\path\\to\\output\\csv" # Path to csv file containing top-n matches
-similarity_threshold = 0 #Change this value appropriately if needed
-# Sample directory path
-# input_directory = "<path to dataset folder>\\LFWdataset\\sample_queries"
-# output_csv = "<path to dataset folder>\\LFWdataset\\output.csv"
+input_directory="../resources/LFWdataset/sample_queries" # Path to directory of query images
+output_csv="../resources/LFWdataset/output.csv" # Path to csv file containing top-n matches
+
+echo "Using similarity threshold: $similarity_threshold"
 
 # Initialize the CSV file with headers
 echo "filename,result" > "$output_csv"
 
 # Iterate over each file in the directory
 for file in "$input_directory"/*; do
-    # Ensure it's a file (not a directory)
-    if [[ -f "$file" ]]; then
-        # Get the filename
-        filename=$(basename "$file")
-
-        # Call the Python script and capture its output
-        result=$(python ../src/Sample_Client/sample_find_face_client.py --file_paths "$file" --similarity_threshold $similarity_threshold --database_name "sample_db" | grep -v "Matches found" | tr '\n' ' ')
-
-        # Append the filename and result as a new row in the CSV file
-        echo "$filename,$result" >> "$output_csv"
-    fi
+  # Ensure it's a file (not a directory)
+  if [[ -f "$file" ]]; then
+    # Get the filename
+    filename=$(basename "$file")
+    # Call the Python script and capture its output
+    result=$(python ../src/Sample_Client/sample_find_face_client.py --file_paths "$file" --similarity_threshold $similarity_threshold --database_name "sample_db" | grep -v "Matches found" | tr '\n' ' ')
+    # Append the filename and result as a new row in the CSV file
+    echo "$filename,$result" >> "$output_csv"
+  fi
 done
 
 # Calculate total time taken
@@ -49,5 +54,4 @@ echo "Server stopped"
 
 # Print total time taken
 echo "Total time taken: $total_time seconds"
-
-read -p "Press any key to exit..."
+#read -p "Press any key to exit..."

--- a/benchmark_testing/run_face_find_time.sh
+++ b/benchmark_testing/run_face_find_time.sh
@@ -14,7 +14,7 @@ sleep 10
 start_time=$(date +%s)
 
 # Call client script to find match for an image (code currently only accepts one file_path at a time)
-python ../src/Sample_Client/sample_find_face_client.py --file_paths "\path\to\image" --database_name "sample_db"
+python ../src/Sample_Client/sample_find_face_client.py --file_paths "../resources/LFWdataset/sample_queries/Al_Gore_0008.jpg" --database_name "sample_db"
 
 # Sample file path
 # "<path to dataset folder>\\LFWdataset\\sample_queries\\image.jpg"

--- a/benchmark_testing/test_data_metrics.py
+++ b/benchmark_testing/test_data_metrics.py
@@ -1,10 +1,10 @@
 import re
-
+import os
 import pandas as pd
 from sklearn.metrics import accuracy_score
 
 # Load the CSV file
-file_path = "path\\to\\output\\csv"  # Path to csv file containing top-n matches
+file_path = "../resources/LFWdataset/output.csv"  # Path to csv file containing top-n matches
 
 # Sample csv path
 # file_path = "<path to dataset folder>\\LFWdataset\\output.csv"
@@ -12,9 +12,13 @@ file_path = "path\\to\\output\\csv"  # Path to csv file containing top-n matches
 data = pd.read_csv(file_path)
 
 # Extract ground truth names (base names without numeric suffixes)
-data["ground_truth"] = data["filename"].apply(
-    lambda x: re.match(r"(.+?)_\d+\.jpg", x).group(1)
-)
+# data["ground_truth"] = data["filename"].apply(
+#     lambda x: re.match(r"(.+?)_\d+\.jpg", x).group(1)
+# )
+def extract_ground_truth(x):
+    match = re.match(r"(.+?)_\d+\.jpg", x)
+    return match.group(1) if match else None
+data["ground_truth"] = data["filename"].apply(extract_ground_truth)
 
 
 # Define a function to check if ground truth matches any predicted name
@@ -25,9 +29,15 @@ def check_match(row):
     # Split the result by spaces to get individual file names
     predicted_names = row["result"].split()
     # Extract base names from each filename
-    predicted_base_names = [
-        re.match(r"(.+?)_\d+\.jpg", name).group(1) for name in predicted_names
-    ]
+    # predicted_base_names = [
+    #     re.match(r"(.+?)_\d+\.jpg", name).group(1) for name in predicted_names
+    # ]
+    predicted_base_names = []
+    for name in predicted_names:
+        base_filename = os.path.basename(name.strip())
+        match = re.match(r"(.+?)_\d+\.jpg", base_filename)
+        if match:
+            predicted_base_names.append(match.group(1))
     # Check if ground_truth matches any of the base names
     return row["ground_truth"] in predicted_base_names
 

--- a/src/facematch/config/model_config.json
+++ b/src/facematch/config/model_config.json
@@ -1,7 +1,7 @@
 { 
-  "_comment": "The cosine threshold value was determined experimentally with database of 1680 images by the FaceMatch team and can be adjusted if needed based on further testing. Models to test: 'Facenet', 'Facenet512', 'ArcFace', 'SFace', 'GhostFaceNet'. Detectors to test: 'retinaface', 'mediapipe', 'yolov8' ",
-  "model_name": "SFace",
-  "detector_backend": "mtcnn",
+  "_comment": "The cosine threshold value was determined experimentally with database of 1680 images by the FaceMatch team and can be adjusted if needed based on further testing.",
+  "model_name": "ArcFace",
+  "detector_backend": "yolov8",
   "euclidian-threshold": 17,
   "cosine-threshold": 0.45, 
   "face_confidence_threshold": 0.7

--- a/src/facematch/config/model_config.json
+++ b/src/facematch/config/model_config.json
@@ -1,7 +1,7 @@
 { 
-  "_comment": "The cosine threshold value was determined experimentally with database of 1680 images by the FaceMatch team and can be adjusted if needed based on further testing.",
-  "model_name": "ArcFace",
-  "detector_backend": "yolov8",
+  "_comment": "The cosine threshold value was determined experimentally with database of 1680 images by the FaceMatch team and can be adjusted if needed based on further testing. Models to test: 'Facenet', 'Facenet512', 'ArcFace', 'SFace', 'GhostFaceNet'. Detectors to test: 'retinaface', 'mediapipe', 'yolov8' ",
+  "model_name": "SFace",
+  "detector_backend": "mtcnn",
   "euclidian-threshold": 17,
   "cosine-threshold": 0.45, 
   "face_confidence_threshold": 0.7


### PR DESCRIPTION
Modified 

- run_face_find_accuracy.sh to include accepting an argument for similarity_threshold
- run_bulk_upload.sh and run_face_find_accuracy.sh to eliminate pressing a key to continue

Added

run_cleanup_and_test.sh which:
-  accepts a similarity_threshold argument
- deletes the current output.csv and database files to start fresh
-  runs run_bulk_upload.sh
- runs run_face_find_accuracy.sh
- use with `./run_cleanup_and_test.sh --threshold <threshold>`  (default is .50)

work completed as part of issue #11 to test model/detector combinations